### PR TITLE
Fix MSAL init: don't mark session authenticated without token

### DIFF
--- a/index.html
+++ b/index.html
@@ -2415,20 +2415,24 @@
             const accounts = msalObj.getAllAccounts();
             if (accounts.length > 0) {
               const account = accounts[0];
-              setSpUser(account);
-              setSpIsAuthenticated(true);
-              // Set email recipient from signed-in user if not already saved
-              if (!localStorage.getItem(STORAGE_KEYS.emailRecipient) && account.username) {
-                setEmailRecipient(account.username);
-              }
               try {
                 const tokenResponse = await msalObj.acquireTokenSilent({
                   scopes: SP_LOGIN_REQUEST.scopes,
                   account: account
                 });
+                // Only mark as authenticated once we actually have a usable token.
+                setSpUser(account);
+                setSpIsAuthenticated(true);
                 setSpAccessToken(tokenResponse.accessToken);
+                if (!localStorage.getItem(STORAGE_KEYS.emailRecipient) && account.username) {
+                  setEmailRecipient(account.username);
+                }
               } catch (err) {
-                console.warn('Silent token acquisition failed, will require interactive sign-in:', err);
+                // No cached refresh token (common on first visit after sign-in in a new
+                // browser/session). Drop the stale account so the UI cleanly prompts for
+                // interactive sign-in instead of appearing signed-in with a dead session.
+                console.info('MSAL: no cached refresh token, clearing stale account and prompting interactive sign-in');
+                try { await msalObj.clearCache(); } catch (e) { /* older MSAL versions lack clearCache */ }
               }
             }
           } catch (error) {


### PR DESCRIPTION
Previously the page-load flow set spIsAuthenticated=true as soon as a cached account was found, then tried to acquire a token silently. When the silent acquisition failed (e.g. no cached refresh token on a fresh browser after earlier sign-in), the UI showed the user as signed in but no valid access token was held, so every SharePoint operation failed with a confusing "no token" error downstream.

Now the flow is: attempt silent token first, and only mark the session authenticated once a token is in hand. On failure, clear the stale account so the UI cleanly presents the sign-in prompt.

Replaces the alarming console.warn stack trace with a brief info log so the developer console no longer looks like something broke.

https://claude.ai/code/session_01DbNjEL1RJLLLD3LnxNaUY1